### PR TITLE
use T instead of f32

### DIFF
--- a/del-geo-core/src/edge2.rs
+++ b/del-geo-core/src/edge2.rs
@@ -95,20 +95,24 @@ where
 
 /// Find the nearest point on a line segment to the origin(0,0)
 /// Returns (k,v), where k is the coeffcient between [0,1], v is the point
-pub fn nearest_origin(ps: &[f32; 2], pe: &[f32; 2]) -> (f32, [f32; 2]) {
+pub fn nearest_origin<T>(ps: &[T; 2], pe: &[T; 2]) -> (T, [T; 2])
+where
+    T: num_traits::Float + 'static,
+    f64: AsPrimitive<T>,
+{
     let d = crate::vec2::sub(pe, ps);
     let a = crate::vec2::squared_length(&d);
-    if a == 0f32 {
-        return (0.5, [(ps[0] + pe[0]) * 0.5, (ps[1] + pe[1]) * 0.5]);
+    if a.is_zero() {
+        return (
+            0.5f64.as_(),
+            std::array::from_fn(|i| (ps[i] + pe[i]) * 0.5f64.as_()),
+        );
     }
     let b = crate::vec2::dot(&d, ps);
-    let r0 = (-b / a).clamp(0., 1.);
+    let r0 = (-b / a).clamp(0f64.as_(), 1f64.as_());
     (
         r0,
-        [
-            (1. - r0) * ps[0] + r0 * pe[0],
-            (1. - r0) * ps[1] + r0 * pe[1],
-        ],
+        std::array::from_fn(|i| (-r0 + 1f64.as_()) * ps[i] + r0 * pe[i]),
     )
 }
 

--- a/del-geo-core/src/edge3.rs
+++ b/del-geo-core/src/edge3.rs
@@ -18,23 +18,16 @@ where
     f64: AsPrimitive<T>,
 {
     use crate::vec3;
-    let d = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
+    let d = std::array::from_fn(|i| p1[i] - p0[i]);
     let t = {
-        if vec3::dot(&d, &d) > 1.0e-20_f64.as_() {
-            let ps = [
-                p0[0] - point_pos[0],
-                p0[1] - point_pos[1],
-                p0[2] - point_pos[2],
-            ];
+        if vec3::dot(&d, &d) > T::epsilon() {
+            let ps = std::array::from_fn(|i| p0[i] - point_pos[i]);
             let a = vec3::dot(&d, &d);
             let b = vec3::dot(&d, &ps);
-            let mut r: T = -b / a;
-            r = if r < 0_f64.as_() { 0_f64.as_() } else { r };
-            r = if r > 1_f64.as_() { 1_f64.as_() } else { r };
-            r
+            (-b / a).clamp(0f64.as_(), 1f64.as_())
         } else {
             0.5_f64.as_()
         }
     };
-    [p0[0] + t * d[0], p0[1] + t * d[1], p0[2] + t * d[2]]
+    std::array::from_fn(|i| p0[i] + t * d[i])
 }


### PR DESCRIPTION
Introduces generic type parameters.

* `del-geo-core/src/edge2.rs`: Updated the `nearest_origin` function to use a generic type `T` constrained by the `num_traits::Float` trait.
* `del-geo-core/src/edge3.rs`: Modified the `nearest_origin` function to use generic type `T`.

And I am thinking about, since some operations are nearly the same, use `<const N: usize>` can unify them. Like the length function.
