### PR TITLE
rewrite some method, add derive attr

### DIFF
--- a/del-geo-core/src/aabb.rs
+++ b/del-geo-core/src/aabb.rs
@@ -83,18 +83,17 @@ where
 }
 
 // -----------------------------
-
-pub struct AABB<'a, Real, const NDIM: usize, const SIZE_AABB: usize> {
-    pub aabb: &'a [Real; SIZE_AABB],
+#[derive(Debug, Clone, Copy)]
+pub struct AABB<Real, const NDIM: usize, const SIZE_AABB: usize> {
+    pub aabb: [Real; SIZE_AABB],
 }
 
-#[allow(clippy::needless_lifetimes)]
-impl<'a, Real, const NDIM: usize, const SIZE_AABB: usize> AABB<'a, Real, NDIM, SIZE_AABB>
+impl<Real, const NDIM: usize, const SIZE_AABB: usize> AABB<Real, NDIM, SIZE_AABB>
 where
     Real: num_traits::Float,
 {
     pub fn is_include_point(&self, point: &[Real; NDIM]) -> bool {
-        is_include_point::<Real, NDIM, SIZE_AABB>(self.aabb, point)
+        is_include_point::<Real, NDIM, SIZE_AABB>(&self.aabb, point)
     }
 
     pub fn intersections_against_ray(
@@ -102,7 +101,7 @@ where
         ray_org: &[Real; NDIM],
         ray_dir: &[Real; NDIM],
     ) -> Option<(Real, Real)> {
-        intersections_against_ray::<Real, NDIM, SIZE_AABB>(self.aabb, ray_org, ray_dir)
+        intersections_against_ray::<Real, NDIM, SIZE_AABB>(&self.aabb, ray_org, ray_dir)
     }
 
     pub fn intersections_against_line(
@@ -110,10 +109,10 @@ where
         line_org: &[Real; NDIM],
         line_dir: &[Real; NDIM],
     ) -> Option<(Real, Real)> {
-        intersections_against_line::<Real, NDIM, SIZE_AABB>(self.aabb, line_org, line_dir)
+        intersections_against_line::<Real, NDIM, SIZE_AABB>(&self.aabb, line_org, line_dir)
     }
 
     pub fn center(&self) -> [Real; NDIM] {
-        center(self.aabb)
+        center(&self.aabb)
     }
 }

--- a/del-geo-core/src/aabb2.rs
+++ b/del-geo-core/src/aabb2.rs
@@ -251,6 +251,6 @@ where
     Real: num_traits::Float,
 {
     AABB2 {
-        aabb: aabbs[(i_aabb * 4)..4].try_into().unwrap(),
+        aabb: aabbs[(i_aabb * 4)..(i_aabb * 4) + 4].try_into().unwrap(),
     }
 }

--- a/del-geo-core/src/aabb2.rs
+++ b/del-geo-core/src/aabb2.rs
@@ -235,14 +235,14 @@ pub fn overlapping_tiles(
 
 // -------------------------------------------------------------------------------
 
-pub type AABB2<'a, Real> = crate::aabb::AABB<'a, Real, 2, 4>;
+pub type AABB2<Real> = crate::aabb::AABB<Real, 2, 4>;
 
 pub fn from_slice<Real>(s: &[Real]) -> AABB2<Real>
 where
     Real: num_traits::Float,
 {
     AABB2 {
-        aabb: arrayref::array_ref!(s, 0, 4),
+        aabb: s[..4].try_into().unwrap(),
     }
 }
 
@@ -251,6 +251,6 @@ where
     Real: num_traits::Float,
 {
     AABB2 {
-        aabb: arrayref::array_ref!(aabbs, i_aabb * 4, 4),
+        aabb: aabbs[(i_aabb * 4)..4].try_into().unwrap(),
     }
 }

--- a/del-geo-core/src/aabb3.rs
+++ b/del-geo-core/src/aabb3.rs
@@ -246,6 +246,6 @@ where
     Real: num_traits::Float,
 {
     AABB3 {
-        aabb: aabbs[(i_aabb * 6)..6].try_into().unwrap(),
+        aabb: aabbs[(i_aabb * 6)..((i_aabb * 6) + 6)].try_into().unwrap(),
     }
 }

--- a/del-geo-core/src/aabb3.rs
+++ b/del-geo-core/src/aabb3.rs
@@ -230,14 +230,14 @@ pub fn is_possible_distance_to_aabb2_smaller_than_threshold(
 
 // --------------------------
 
-pub type AABB3<'a, Real> = crate::aabb::AABB<'a, Real, 3, 6>;
+pub type AABB3<Real> = crate::aabb::AABB<Real, 3, 6>;
 
 pub fn from_slice<Real>(s: &[Real]) -> AABB3<Real>
 where
     Real: num_traits::Float,
 {
     AABB3 {
-        aabb: arrayref::array_ref!(s, 0, 6),
+        aabb: s[..6].try_into().unwrap(),
     }
 }
 
@@ -246,6 +246,6 @@ where
     Real: num_traits::Float,
 {
     AABB3 {
-        aabb: arrayref::array_ref!(aabbs, i_aabb * 6, 6),
+        aabb: aabbs[(i_aabb * 6)..6].try_into().unwrap(),
     }
 }

--- a/del-geo-core/src/mat2_sym.rs
+++ b/del-geo-core/src/mat2_sym.rs
@@ -165,7 +165,7 @@ fn test_prinsipal_directions() {
         {
             let tmp0 = nalgebra::Vector2::<f32>::from_row_slice(&matvec(
                 &mat,
-                arrayref::array_ref![evec0.as_slice(), 0, 2],
+                evec0.as_slice()[..2].try_into().unwrap(),
             ));
             let diff = (tmp0 - lam0 * evec0).norm();
             assert!(diff < 1.0e-6, "{}", diff);
@@ -173,7 +173,7 @@ fn test_prinsipal_directions() {
         {
             let tmp0 = nalgebra::Vector2::<f32>::from_row_slice(&matvec(
                 &mat,
-                arrayref::array_ref![evec1.as_slice(), 0, 2],
+                evec1.as_slice()[..2].try_into().unwrap(),
             ));
             assert!((tmp0 - lam1 * evec1).norm() < 1.0e-6);
         }

--- a/del-geo-core/src/obb2.rs
+++ b/del-geo-core/src/obb2.rs
@@ -4,6 +4,37 @@
 //! next 2 Reals are for half of major axis direction
 //! next 2 Reals are for half of minar axis direction
 
+use crate::vec2::Vec2;
+
+pub trait OBB2Trait<T>
+where
+    Self: Sized,
+{
+    fn is_include_point2(&self, p: &[T; 2]) -> bool;
+    fn corner_points(&self) -> [[T; 2]; 4];
+    fn nearest_point2(&self, p: &[T; 2]) -> [T; 2];
+    fn is_intersect_aabb2(&self, aabb: &[T; 4]) -> bool;
+    fn is_intersect_obb2(&self, obb: &[T; 6]) -> bool;
+}
+
+impl OBB2Trait<f32> for [f32; 6] {
+    fn is_include_point2(&self, p: &[f32; 2]) -> bool {
+        is_include_point2(self, p)
+    }
+    fn corner_points(&self) -> [[f32; 2]; 4] {
+        corner_points(self)
+    }
+    fn nearest_point2(&self, p: &[f32; 2]) -> [f32; 2] {
+        nearest_point2(self, p)
+    }
+    fn is_intersect_aabb2(&self, aabb: &[f32; 4]) -> bool {
+        is_intersect_aabb2(self, aabb)
+    }
+    fn is_intersect_obb2(&self, obb: &[f32; 6]) -> bool {
+        is_intersect_obb2(self, obb)
+    }
+}
+
 pub fn from_random<RAND>(reng: &mut RAND) -> [f32; 6]
 where
     RAND: rand::Rng,
@@ -16,19 +47,19 @@ where
 }
 
 fn is_include_point2(obb: &[f32; 6], p: &[f32; 2]) -> bool {
-    let d = crate::vec2::sub(p, arrayref::array_ref!(obb, 0, 2));
+    let d = p.sub(obb[..2].try_into().unwrap());
     {
-        let v = arrayref::array_ref!(obb, 2, 2);
-        let vd = crate::vec2::dot(&d, v);
-        let vv = crate::vec2::dot(v, v);
+        let v = obb[2..4].try_into().unwrap();
+        let vd = d.dot(v);
+        let vv = v.dot(v);
         if vd < -vv || vd > vv {
             return false;
         }
     }
     {
-        let v = arrayref::array_ref!(obb, 4, 2);
-        let vd = crate::vec2::dot(&d, v);
-        let vv = crate::vec2::dot(v, v);
+        let v = obb[4..6].try_into().unwrap();
+        let vd = d.dot(v);
+        let vv = v.dot(v);
         if vd < -vv || vd > vv {
             return false;
         }

--- a/del-geo-core/src/obb2.rs
+++ b/del-geo-core/src/obb2.rs
@@ -14,7 +14,7 @@ where
     fn corner_points(&self) -> [[T; 2]; 4];
     fn nearest_point2(&self, p: &[T; 2]) -> [T; 2];
     fn is_intersect_aabb2(&self, aabb: &[T; 4]) -> bool;
-    fn is_intersect_obb2(&self, obb: &[T; 6]) -> bool;
+    fn is_intersect_obb2(&self, obb: &Self) -> bool;
 }
 
 impl OBB2Trait<f32> for [f32; 6] {
@@ -30,7 +30,7 @@ impl OBB2Trait<f32> for [f32; 6] {
     fn is_intersect_aabb2(&self, aabb: &[f32; 4]) -> bool {
         is_intersect_aabb2(self, aabb)
     }
-    fn is_intersect_obb2(&self, obb: &[f32; 6]) -> bool {
+    fn is_intersect_obb2(&self, obb: &Self) -> bool {
         is_intersect_obb2(self, obb)
     }
 }
@@ -39,10 +39,11 @@ pub fn from_random<RAND>(reng: &mut RAND) -> [f32; 6]
 where
     RAND: rand::Rng,
 {
+    use crate::vec2::Vec2;
     let cntr = [2. * reng.gen::<f32>() - 1., 2. * reng.gen::<f32>() - 1.];
     let u = [2. * reng.gen::<f32>() - 1., 2. * reng.gen::<f32>() - 1.];
     let v = [2. * reng.gen::<f32>() - 1., 2. * reng.gen::<f32>() - 1.];
-    let v = crate::vec2::orthogonalize(&u, &v);
+    let v = u.orthogonalize(&v);
     [cntr[0], cntr[1], u[0], u[1], v[0], v[1]]
 }
 

--- a/del-geo-core/src/obb3.rs
+++ b/del-geo-core/src/obb3.rs
@@ -251,7 +251,7 @@ fn test_is_intersect_to_obb3() {
     for _iter in 0..1000 {
         let obb_i = from_random::<_, f64>(&mut reng);
         let obb_j = from_random(&mut reng);
-        let p0 = arrayref::array_ref![obb_i, 0, 3]; // center
+        let p0 = obb_i[..3].try_into().unwrap(); // center
         let p1 = obb_j.nearest_to_point3(p0);
         let p2 = obb_i.nearest_to_point3(&p1);
         let p3 = obb_j.nearest_to_point3(&p2);
@@ -310,7 +310,7 @@ fn test2_is_intersect_to_obb3() {
             d, 0., -d, u[0], u[1], u[2], v[0], v[1], v[2], w[0], w[1], w[2],
         ];
 
-        let p0 = arrayref::array_ref![obb_i, 0, 3]; // center
+        let p0 = obb_i[..3].try_into().unwrap(); // center
         let p1 = obb_j.nearest_to_point3(p0);
         let p2 = obb_i.nearest_to_point3(&p1);
         let p3 = obb_j.nearest_to_point3(&p2);

--- a/del-geo-core/src/tri2.rs
+++ b/del-geo-core/src/tri2.rs
@@ -91,24 +91,22 @@ pub fn dldx<T>(p0: &[T; 2], p1: &[T; 2], p2: &[T; 2]) -> ([[T; 3]; 2], [T; 3])
 where
     T: num_traits::Float,
 {
+    use crate::vec3::Vec3;
     assert!(p0.len() == 2 && p1.len() == 2 && p2.len() == 2);
     let half = T::one() / (T::one() + T::one());
     let a0 = area(p0, p1, p2);
     let tmp1: T = half / a0;
     (
         [
-            [(p1[1] - p2[1]), (p2[1] - p0[1]), (p0[1] - p1[1])],
-            [
-                tmp1 * (p2[0] - p1[0]),
-                tmp1 * (p0[0] - p2[0]),
-                tmp1 * (p1[0] - p0[0]),
-            ],
+            [p1[1] - p2[1], p2[1] - p0[1], p0[1] - p1[1]].scale(tmp1),
+            [p2[0] - p1[0], p0[0] - p2[0], p1[0] - p0[0]].scale(tmp1),
         ],
         [
-            tmp1 * (p1[0] * p2[1] - p2[0] * p1[1]),
-            tmp1 * (p2[0] * p0[1] - p0[0] * p2[1]),
-            tmp1 * (p0[0] * p1[1] - p1[0] * p0[1]),
-        ],
+            p1[0] * p2[1] - p2[0] * p1[1],
+            p2[0] * p0[1] - p0[0] * p2[1],
+            p0[0] * p1[1] - p1[0] * p0[1],
+        ]
+        .scale(tmp1),
     )
 }
 
@@ -143,12 +141,9 @@ impl<Real> Tri2<Real>
 where
     Real: num_traits::Float,
 {
-    pub fn is_inside<P>(&self, q: P, sign: Real) -> Option<(Real, Real)>
-    where
-        P: AsRef<[Real; 2]>,
-    {
+    pub fn is_inside(&self, q: &[Real; 2], sign: Real) -> Option<(Real, Real)> {
         let Tri2 { p0, p1, p2 } = self;
-        is_inside(p0, p1, p2, q.as_ref(), sign)
+        is_inside(p0, p1, p2, q, sign)
     }
 
     pub fn area(&self) -> Real {

--- a/del-geo-core/src/tri2.rs
+++ b/del-geo-core/src/tri2.rs
@@ -1,5 +1,7 @@
 //! methods for 2D triangle
 
+use crate::vec2::Vec2;
+
 pub fn area<T>(p0: &[T; 2], p1: &[T; 2], p2: &[T; 2]) -> T
 where
     T: num_traits::Float,
@@ -20,9 +22,9 @@ where
     let dareadp1x2 = [p2[1] - p0[1], p0[0] - p2[0]];
     let dareadp2x2 = [p0[1] - p1[1], p1[0] - p0[0]];
     (
-        crate::vec2::scale(&dareadp0x2, dldarea * half),
-        crate::vec2::scale(&dareadp1x2, dldarea * half),
-        crate::vec2::scale(&dareadp2x2, dldarea * half),
+        dareadp0x2.scale(dldarea * half),
+        dareadp1x2.scale(dldarea * half),
+        dareadp2x2.scale(dldarea * half),
     )
 }
 
@@ -95,11 +97,7 @@ where
     let tmp1: T = half / a0;
     (
         [
-            [
-                tmp1 * (p1[1] - p2[1]),
-                tmp1 * (p2[1] - p0[1]),
-                tmp1 * (p0[1] - p1[1]),
-            ],
+            [(p1[1] - p2[1]), (p2[1] - p0[1]), (p0[1] - p1[1])],
             [
                 tmp1 * (p2[0] - p1[0]),
                 tmp1 * (p0[0] - p2[0]),
@@ -134,23 +132,27 @@ where
 }
 
 // -------------------------------------------
-
-pub struct Tri2<'a, Real> {
-    pub p0: &'a [Real; 2],
-    pub p1: &'a [Real; 2],
-    pub p2: &'a [Real; 2],
+#[derive(Debug, Clone, Copy)]
+pub struct Tri2<Real> {
+    pub p0: [Real; 2],
+    pub p1: [Real; 2],
+    pub p2: [Real; 2],
 }
 
-#[allow(clippy::needless_lifetimes)]
-impl<'a, Real> Tri2<'a, Real>
+impl<Real> Tri2<Real>
 where
     Real: num_traits::Float,
 {
-    pub fn is_inside(&self, q: &[Real; 2], sign: Real) -> Option<(Real, Real)> {
-        is_inside(self.p0, self.p1, self.p2, q, sign)
+    pub fn is_inside<P>(&self, q: P, sign: Real) -> Option<(Real, Real)>
+    where
+        P: AsRef<[Real; 2]>,
+    {
+        let Tri2 { p0, p1, p2 } = self;
+        is_inside(p0, p1, p2, q.as_ref(), sign)
     }
 
     pub fn area(&self) -> Real {
-        area(self.p0, self.p1, self.p2)
+        let Tri2 { p0, p1, p2 } = self;
+        area(p0, p1, p2)
     }
 }

--- a/del-geo-core/src/tri3.rs
+++ b/del-geo-core/src/tri3.rs
@@ -339,15 +339,14 @@ where
 }
 
 // -------------------------
-
-pub struct Tri3<'a, Real> {
-    pub p0: &'a [Real; 3],
-    pub p1: &'a [Real; 3],
-    pub p2: &'a [Real; 3],
+#[derive(Debug, Copy, Clone)]
+pub struct Tri3<Real> {
+    pub p0: [Real; 3],
+    pub p1: [Real; 3],
+    pub p2: [Real; 3],
 }
 
-#[allow(clippy::needless_lifetimes)]
-impl<'a, Real> Tri3<'a, Real>
+impl<Real> Tri3<Real>
 where
     Real: num_traits::Float,
 {
@@ -356,7 +355,7 @@ where
         ray_org: &[Real; 3],
         ray_dir: &[Real; 3],
     ) -> Option<Real> {
-        intersection_against_line(self.p0, self.p1, self.p2, ray_org, ray_dir)
+        intersection_against_line(&self.p0, &self.p1, &self.p2, ray_org, ray_dir)
             .filter(|&t| t >= Real::zero())
     }
 
@@ -365,11 +364,11 @@ where
         line_org: &[Real; 3],
         line_dir: &[Real; 3],
     ) -> Option<Real> {
-        intersection_against_line(self.p0, self.p1, self.p2, line_org, line_dir)
+        intersection_against_line(&self.p0, &self.p1, &self.p2, line_org, line_dir)
     }
 
     pub fn area(&self) -> Real {
-        area(self.p0, self.p1, self.p2)
+        area(&self.p0, &self.p1, &self.p2)
     }
 
     pub fn cog(&self) -> [Real; 3] {
@@ -383,11 +382,11 @@ where
     }
 
     pub fn normal(&self) -> [Real; 3] {
-        normal(self.p0, self.p1, self.p2)
+        normal(&self.p0, &self.p1, &self.p2)
     }
 
     pub fn unit_normal(&self) -> [Real; 3] {
-        let n = normal(self.p0, self.p1, self.p2);
+        let n = normal(&self.p0, &self.p1, &self.p2);
         use crate::vec3::Vec3;
         n.normalize()
     }

--- a/del-geo-core/src/tri3.rs
+++ b/del-geo-core/src/tri3.rs
@@ -372,13 +372,15 @@ where
     }
 
     pub fn cog(&self) -> [Real; 3] {
+        use crate::vec3::Vec3;
         let one = Real::one();
         let one3rd = one / (one * one * one);
         [
-            (self.p0[0] + self.p1[0] + self.p2[0]) * one3rd,
-            (self.p0[1] + self.p1[1] + self.p2[1]) * one3rd,
-            (self.p0[2] + self.p1[2] + self.p2[2]) * one3rd,
+            (self.p0[0] + self.p1[0] + self.p2[0]),
+            (self.p0[1] + self.p1[1] + self.p2[1]),
+            (self.p0[2] + self.p1[2] + self.p2[2]),
         ]
+        .scale(one3rd)
     }
 
     pub fn normal(&self) -> [Real; 3] {

--- a/del-geo-core/src/uvec3.rs
+++ b/del-geo-core/src/uvec3.rs
@@ -1,4 +1,16 @@
 //! methods for unit 3D vector
+pub trait UVec3 {
+    fn map_to_unit2_octahedron(&self) -> [f32; 2];
+    fn map_to_unit2_equal_area(&self) -> [f32; 2];
+}
+impl UVec3 for [f32; 3] {
+    fn map_to_unit2_octahedron(&self) -> [f32; 2] {
+        map_to_unit2_octahedron(self)
+    }
+    fn map_to_unit2_equal_area(&self) -> [f32; 2] {
+        map_to_unit2_equal_area(self)
+    }
+}
 
 pub fn map_to_unit2_octahedron(dir: &[f32; 3]) -> [f32; 2] {
     let n = dir[0].abs() + dir[1].abs() + dir[2].abs();

--- a/del-geo-core/src/vec2.rs
+++ b/del-geo-core/src/vec2.rs
@@ -7,6 +7,8 @@ where
     fn sub(&self, other: &Self) -> Self;
     fn add(&self, other: &Self) -> Self;
     fn transform_homogeneous(&self, v: &[Real; 9]) -> Option<[Real; 2]>;
+    fn dot(&self, other: &Self) -> Real;
+    fn scale(&self, s: Real) -> Self;
 }
 
 impl<Real> Vec2<Real> for [Real; 2]
@@ -21,6 +23,12 @@ where
     }
     fn transform_homogeneous(&self, v: &[Real; 9]) -> Option<Self> {
         crate::mat3_col_major::transform_homogeneous(v, self)
+    }
+    fn dot(&self, other: &Self) -> Real {
+        dot(self, other)
+    }
+    fn scale(&self, s: Real) -> Self {
+        scale(self, s)
     }
 }
 
@@ -42,21 +50,21 @@ pub fn sub<T>(a: &[T; 2], b: &[T; 2]) -> [T; 2]
 where
     T: std::ops::Sub<Output = T> + Copy,
 {
-    [a[0] - b[0], a[1] - b[1]]
+    std::array::from_fn(|i| a[i] - b[i])
 }
 
 pub fn add<T>(a: &[T; 2], b: &[T; 2]) -> [T; 2]
 where
     T: std::ops::Add<Output = T> + Copy,
 {
-    [a[0] + b[0], a[1] + b[1]]
+    std::array::from_fn(|i| a[i] + b[i])
 }
 
 pub fn scale<T>(a: &[T; 2], s: T) -> [T; 2]
 where
     T: num_traits::Float,
 {
-    [a[0] * s, a[1] * s]
+    std::array::from_fn(|i| a[i] * s)
 }
 
 pub fn dot<T>(a: &[T; 2], b: &[T; 2]) -> T
@@ -77,7 +85,7 @@ pub fn angle_between_two_vecs<T>(a: &[T; 2], b: &[T; 2]) -> T
 where
     T: num_traits::Float,
 {
-    let dot = dot(a, b);
+    let dot = a.dot(b);
     let area = area_quadrilateral(a, b);
     area.atan2(dot)
 }
@@ -142,29 +150,29 @@ pub fn rotate(p: &[f32; 2], theta: f32) -> [f32; 2] {
 
 pub fn normalize(p: &[f32; 2]) -> [f32; 2] {
     let invl = 1.0 / (p[0] * p[0] + p[1] * p[1]).sqrt();
-    [p[0] * invl, p[1] * invl]
+    p.scale(invl)
 }
 
 pub fn orthogonalize(u: &[f32; 2], v: &[f32; 2]) -> [f32; 2] {
     let t = dot(u, v) / dot(u, u);
-    [v[0] - t * u[0], v[1] - t * u[1]]
+    v.sub(&u.scale(t))
 }
 
 pub fn axpy<Real>(alpha: Real, x: &[Real; 2], y: &[Real; 2]) -> [Real; 2]
 where
     Real: num_traits::Float,
 {
-    [alpha * x[0] + y[0], alpha * x[1] + y[1]]
+    x.scale(alpha).add(y)
 }
 
 // -------------------------------
 // below: about the Vec2 class
-pub struct XY<'a, Real> {
-    pub p: &'a [Real; 2],
+#[derive(Debug, Clone, Copy)]
+pub struct XY<Real> {
+    pub p: [Real; 2],
 }
 
-#[allow(clippy::needless_lifetimes)]
-impl<'a, Real> XY<'a, Real>
+impl<Real> XY<Real>
 where
     Real: num_traits::Float,
 {

--- a/del-geo-core/src/vec2.rs
+++ b/del-geo-core/src/vec2.rs
@@ -9,6 +9,7 @@ where
     fn transform_homogeneous(&self, v: &[Real; 9]) -> Option<[Real; 2]>;
     fn dot(&self, other: &Self) -> Real;
     fn scale(&self, s: Real) -> Self;
+    fn orthogonalize(&self, v: &Self) -> Self;
 }
 
 impl<Real> Vec2<Real> for [Real; 2]
@@ -29,6 +30,9 @@ where
     }
     fn scale(&self, s: Real) -> Self {
         scale(self, s)
+    }
+    fn orthogonalize(&self, v: &Self) -> Self {
+        orthogonalize(self, v)
     }
 }
 
@@ -153,8 +157,11 @@ pub fn normalize(p: &[f32; 2]) -> [f32; 2] {
     p.scale(invl)
 }
 
-pub fn orthogonalize(u: &[f32; 2], v: &[f32; 2]) -> [f32; 2] {
-    let t = dot(u, v) / dot(u, u);
+pub fn orthogonalize<T>(u: &[T; 2], v: &[T; 2]) -> [T; 2]
+where
+    T: num_traits::Float,
+{
+    let t = u.dot(v) / u.dot(u);
     v.sub(&u.scale(t))
 }
 

--- a/del-geo-core/src/vec3.rs
+++ b/del-geo-core/src/vec3.rs
@@ -338,6 +338,7 @@ where
 }
 
 // ------------------------------------------
+#[derive(Debug, Clone, Copy)]
 pub struct XYZ<Real> {
     pub p: [Real; 3],
 }

--- a/del-geo-core/src/vec3.rs
+++ b/del-geo-core/src/vec3.rs
@@ -78,7 +78,7 @@ where
     Real: num_traits::Float,
 {
     let t = u.dot(v) / u.dot(u);
-    [v[0] - t * u[0], v[1] - t * u[1], v[2] - t * u[2]]
+    v.sub(&u.scale(t))
 }
 
 pub fn to_mat3_from_axisangle_vec<T>(vec: &[T; 3]) -> [T; 9]
@@ -86,7 +86,7 @@ where
     T: num_traits::Float,
 {
     let one = T::one();
-    let sqt = vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2];
+    let sqt = vec.squared_norm();
     if sqt <= T::epsilon() {
         // infinitesimal rotation approximation
         return [
@@ -128,29 +128,29 @@ where
     let one = Real::one();
     let zero = Real::zero();
     let vec_s: [Real; 3] = [zero, one, zero];
-    let vec_x = cross(&vec_s, vec_n);
-    let len = norm(&vec_x);
+    let vec_x = vec_s.cross(vec_n);
+    let len = vec_x.norm();
     if len < Real::epsilon() {
         let vec_t = [one, zero, zero];
-        let vec_x = cross(&vec_t, vec_n); // z????
-        let vec_y = cross(vec_n, &vec_x); // x????
+        let vec_x = vec_t.cross(vec_n); // z????
+        let vec_y = vec_n.cross(&vec_x); // x????
         (vec_x, vec_y)
     } else {
         let invlen = one / len;
-        let vec_x = [vec_x[0] * invlen, vec_x[1] * invlen, vec_x[2] * invlen];
-        let vec_y = cross(vec_n, &vec_x);
+        let vec_x = vec_x.scale(invlen);
+        let vec_y = vec_n.cross(&vec_x);
         (vec_x, vec_y)
     }
 }
 
 #[test]
 fn test_basis_xy_from_basis_z() {
-    let vec_z = normalize(&[0.3, 0.1, -0.5]);
+    let vec_z = [0.3, 0.1, -0.5].normalize();
     let (vec_x, vec_y) = basis_xy_from_basis_z(&vec_z);
     let bases = [vec_x, vec_y, vec_z];
     for i in 0..3 {
         for j in i..3 {
-            let dij: f64 = dot(&bases[i], &bases[j]);
+            let dij: f64 = bases[i].dot(&bases[j]);
             if i == j {
                 assert!((dij - 1.0).abs() < 1.0e-5);
             } else {
@@ -179,16 +179,14 @@ pub fn add<T>(a: &[T; 3], b: &[T; 3]) -> [T; 3]
 where
     T: num_traits::Float,
 {
-    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+    std::array::from_fn(|i| a[i] + b[i])
 }
 
 pub fn add_in_place<T>(a: &mut [T; 3], b: &[T; 3])
 where
     T: num_traits::Float,
 {
-    a[0] = a[0] + b[0];
-    a[1] = a[1] + b[1];
-    a[2] = a[2] + b[2];
+    *a = a.add(b);
 }
 
 pub fn squared_norm<T>(p: &[T; 3]) -> T
@@ -203,7 +201,7 @@ pub fn norm<T>(v: &[T; 3]) -> T
 where
     T: num_traits::Float,
 {
-    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+    v.squared_norm().sqrt()
 }
 
 /// in-place normalize function
@@ -213,9 +211,7 @@ where
 {
     let l = v.norm();
     let linv = T::one() / l;
-    v[0] = v[0] * linv;
-    v[1] = v[1] * linv;
-    v[2] = v[2] * linv;
+    *v = v.scale(linv);
     l
 }
 
@@ -226,7 +222,7 @@ where
 {
     let l = v.norm();
     let linv = T::one() / l;
-    std::array::from_fn(|i| v[i] * linv)
+    v.scale(linv)
 }
 
 pub fn cross_mut<T>(vo: &mut [T; 3], v1: &[T; 3], v2: &[T; 3])
@@ -264,31 +260,28 @@ pub fn sub<T>(a: &[T; 3], b: &[T; 3]) -> [T; 3]
 where
     T: std::ops::Sub<Output = T> + Copy,
 {
-    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+    std::array::from_fn(|i| a[i] - b[i])
 }
 
 pub fn scale<T>(a: &[T; 3], s: T) -> [T; 3]
 where
     T: Copy + std::ops::Mul<Output = T>,
 {
-    [s * a[0], s * a[1], s * a[2]]
+    std::array::from_fn(|i| a[i] * s)
 }
 
 pub fn scale_in_place<T>(a: &mut [T; 3], s: T)
 where
     T: num_traits::Float,
 {
-    for x in a.iter_mut() {
-        *x = *x * s;
-    }
+    *a = a.scale(s);
 }
 
 pub fn distance<T>(p0: &[T; 3], p1: &[T; 3]) -> T
 where
     T: num_traits::Float,
 {
-    let [v0, v1, v2] = p1.sub(p0);
-    (v0 * v0 + v1 * v1 + v2 * v2).sqrt()
+    p1.sub(p0).norm()
 }
 
 pub fn scalar_triple_product<T>(a: &[T; 3], b: &[T; 3], c: &[T; 3]) -> T
@@ -305,7 +298,7 @@ pub fn axpy<Real>(alpha: Real, x: &[Real; 3], y: &[Real; 3]) -> [Real; 3]
 where
     Real: num_traits::Float,
 {
-    std::array::from_fn(|i| alpha * x[i] + y[i])
+    x.scale(alpha).add(y)
 }
 
 pub fn to_quaternion_from_axis_angle_vector<Real>(a: &[Real; 3]) -> [Real; 4]
@@ -316,7 +309,7 @@ where
     let two = one + one;
     let half = one / two;
     let one8th = one / (two * two * two);
-    let sqlen = a[0] * a[0] + a[1] * a[1] + a[2] * a[2];
+    let sqlen = a.squared_norm();
     if sqlen <= Real::epsilon() {
         return [half * a[0], half * a[1], half * a[2], one - one8th * sqlen];
     }
@@ -345,12 +338,11 @@ where
 }
 
 // ------------------------------------------
-pub struct XYZ<'a, Real> {
-    pub p: &'a [Real; 3],
+pub struct XYZ<Real> {
+    pub p: [Real; 3],
 }
 
-#[allow(clippy::needless_lifetimes)]
-impl<'a, Real> XYZ<'a, Real>
+impl<Real> XYZ<Real>
 where
     Real: num_traits::Float,
 {

--- a/del-geo-core/src/view_projection.rs
+++ b/del-geo-core/src/view_projection.rs
@@ -1,5 +1,5 @@
 use crate::mat4_col_major::Mat4ColMajor;
-
+#[derive(Debug, Clone, Copy)]
 pub struct Perspective {
     pub lens: f32,
     pub near: f32,

--- a/del-geo-core/src/view_rotation.rs
+++ b/del-geo-core/src/view_rotation.rs
@@ -1,5 +1,5 @@
 use crate::quaternion::Quaternion;
-
+#[derive(Debug, Clone, Copy)]
 pub struct Trackball {
     pub quaternion: [f32; 4],
 }


### PR DESCRIPTION
> [fmt::Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) implementations should be implemented for all public types. Output will typically represent the internal state as faithfully as possible. The purpose of the [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait is to facilitate debugging Rust code. In most cases, using #[derive(Debug)] is sufficient and recommended.

ref <https://doc.rust-lang.org/std/fmt/index.html#fmtdisplay-vs-fmtdebug> so I add them.

